### PR TITLE
Adds base support for IPs over load balancers / proxies using X-FORWARDED-FOR header.

### DIFF
--- a/throttle.go
+++ b/throttle.go
@@ -25,6 +25,9 @@ const (
 
 	// The default key prefix for Key Value Storage
 	defaultKeyPrefix = "throttle"
+
+	// The header name to retrieve an IP address under a proxy
+	forwardedForHeader = "X-FORWARDED-FOR"
 )
 
 type Options struct {
@@ -248,7 +251,7 @@ func setRateLimitHeaders(resp http.ResponseWriter, controller *controller, id st
 
 // The default identifier function. Identifies a client by IP
 func defaultIdentify(req *http.Request) string {
-	if forwardedFor := req.Header.Get("X-FORWARDED-FOR"); forwardedFor != "" {
+	if forwardedFor := req.Header.Get(forwardedForHeader); forwardedFor != "" {
 		if ipParsed := net.ParseIP(forwardedFor); ipParsed != nil {
 			return ipParsed.String()
 		}


### PR DESCRIPTION
If you're using throttle middleware under an Nginx configuration, you'll ended up blocking almost every user by default, unless you create your own function to "check" who is who. This commit tries to solve at least the minor problem detecting if a X-FORWARDED-FOR header comes with the request, and if so, returns the IP from that header instead of the detected by Go.
