### PR TITLE
Improve compatibility with negroni and other http-based middleware.

### DIFF
--- a/throttle.go
+++ b/throttle.go
@@ -9,8 +9,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/go-martini/martini"
 )
 
 const (
@@ -217,11 +215,11 @@ func (o *Options) Identify(req *http.Request) string {
 // access to resources will be denied to this user
 // Second is Options to use with this policy. For further information on options,
 // see Options further above.
-func Policy(quota *Quota, options ...*Options) martini.Handler {
+func Policy(quota *Quota, options ...*Options) func(resp http.ResponseWriter, req *http.Request) {
 	o := newOptions(options)
 	controller := newController(quota, o.Store)
 
-	return func(context martini.Context, resp http.ResponseWriter, req *http.Request) {
+	return func(resp http.ResponseWriter, req *http.Request) {
 		id := makeKey(o.KeyPrefix, quota.KeyId(), o.Identify(req))
 
 		if controller.DeniesAccess(id) {


### PR DESCRIPTION
Throttle looks like a really handy tool, and I'm interested in adapting it to work with [negroni](https://github.com/codegangsta/negroni). This small change makes it easier to write a negroni-compatible middleware wrapper around the throttle handler.

For example, I can now write negroni-compatible middleware (which uses throttle behind the scenes) in just a few lines:

``` go
func Policy(quota *throttle.Quota, options ...*throttle.Options) negroni.HandlerFunc {
    return func(res http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
        handler := throttle.Policy(quota, options...)
        handler(res, req)
        if res.Header().Get("X-Ratelimit-Remaining") == "0" {
            // the policy was triggered and the request should fail
            // in this case, we should not call next
        } else {
            // the policy was not triggered, and the request should continue
            // on to the next handler
            next(res, req)
        }
    }
}
```

I expect that this will also make throttle more compatible for those who prefer to roll their own middleware micro-frameworks. The tests still pass, and Policy still returns a handler which is directly compatible with martini, so as far as I know this change comes with no downsides.
